### PR TITLE
Fix duplicate test item IDs when assertions share the same message

### DIFF
--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -80,7 +80,7 @@ export async function updateFromDisk(
                     should,
                     thisGeneration
                 );
-                const id = `${fileItem.uri}/${data.getLabel()}`;
+                const id = `${parent.item.id}/${range.start.line}`;
                 const tcase = controller.createTestItem(id, data.getLabel(), fileItem.uri);
                 tcase.range = range;
                 testData.set(tcase, data);


### PR DESCRIPTION
## Summary
- Fixed duplicate test item ID error when multiple assertions use the same message
- Changed ID generation from using assertion message to parent function ID + line number

## Problem
The extension would fail to discover tests with error: `Attempted to insert a duplicate test item ID` when multiple assertions across different test functions had the same "should" message (e.g., "Normalized should be empty").

## Solution
Modified `src/testTree.ts:83` to generate unique test IDs using `${parent.item.id}/${range.start.line}` instead of `${fileItem.uri}/${data.getLabel()}`.

## Test plan
- [x] Tested with file containing duplicate assertion messages
- [x] Tests now discover successfully without ID conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)