### PR TITLE
Fix JSON parsing to handle extra output from 4D

### DIFF
--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -99,7 +99,18 @@ export async function startTestRun(
             makeProcess.on('close', () => {
                 try {
                     if (output.trim().length > 0) {
-                        const results = JSON.parse(output);
+                        // Extract JSON from output - find first { and last }
+                        const firstBrace = output.indexOf('{');
+                        const lastBrace = output.lastIndexOf('}');
+
+                        if (firstBrace === -1 || lastBrace === -1 || firstBrace > lastBrace) {
+                            run.appendOutput(`Could not find valid JSON in output\n`);
+                            resolve();
+                            return;
+                        }
+
+                        const jsonStr = output.substring(firstBrace, lastBrace + 1);
+                        const results = JSON.parse(jsonStr);
 
                         // Pretty JSON, fixed header
                         const pretty = JSON.stringify(results, null, 2);
@@ -112,6 +123,7 @@ export async function startTestRun(
                     }
                 } catch (err: any) {
                     run.appendOutput(`Error parsing JSON: ${err.message}\n`);
+                    run.appendOutput(`Output was:\n${output}\n`);
                 }
                 resolve();
             });


### PR DESCRIPTION
## Summary
- Fixed test runner JSON parsing to handle extra console output from 4D
- Parser now extracts JSON by finding first `{` and last `}` instead of parsing entire output

## Problem
The test runner was attempting to parse the entire stdout as JSON, but 4D sometimes outputs additional text before or after the test results JSON. This extra output is out of our control and comes from 4D's initialization or other system messages.

Example of failing output:
```
tool4d.APPL Cooperative process doesn't yield enough (executionTime=863, task=-1, taskName=Main task, stackCrawl=)
tool4d.APPL Cooperative process doesn't yield enough (executionTime=863, task=-1, taskName=Main task, stackCrawl=)

{
  "tests": 0,
  "passed": 0,
  ...
}
```

The JSON parser would fail because it tried to parse the internal 4D "tool4d.APPL Cooperative process..." line as JSON.

## Solution
Modified `src/startTestRun.ts:102-113` to:
1. Find the first `{` character in the output
2. Find the last `}` character in the output  
3. Extract only the substring between these braces
4. Parse that substring as JSON

This approach is robust to any text before or after the JSON object.

## Test Plan
- [x] Tested with output containing text before JSON
- [x] Tested with output containing text after JSON
- [x] Verified clean JSON still parses correctly
- [x] Added error handling for cases where no valid JSON found

🤖 Generated with [Claude Code](https://claude.com/claude-code)