### PR TITLE
Refactor to function-level TestItems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "4d-testing-extension",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "4d-testing-extension",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "devDependencies": {
         "@types/node": "^20.11.30",
         "@types/vscode": "^1.85.0",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,3 +42,79 @@ export const parseMarkdown = (
 
     return foundFunction;
 };
+
+/**
+ * Maps a 4D function-relative line number to the actual source file line number.
+ *
+ * 4D counts lines with continuation characters (\) as a single line, but the source
+ * file stores them as multiple lines. This function accounts for that difference.
+ *
+ * @param fileUri - URI of the source file
+ * @param functionName - Fully qualified function name (e.g., "ClassName.methodName")
+ * @param lineOffset - Line offset from the function start (1-based, as reported by 4D)
+ * @returns The actual line number in the source file (0-based), or null if not found
+ */
+export async function mapFunctionLineToSourceLine(
+    fileUri: vscode.Uri,
+    functionName: string,
+    lineOffset: number
+): Promise<number | null> {
+    try {
+        // Read the source file
+        const rawContent = await vscode.workspace.fs.readFile(fileUri);
+        const content = new TextDecoder().decode(rawContent);
+        const lines = content.split('\n');
+
+        // Extract the method name from the fully qualified name
+        // Format is typically "ClassName.methodName" or just "methodName"
+        const methodName = functionName.split('.').pop() || functionName;
+
+        // Find the function definition line
+        let functionStartLine = -1;
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].trim();
+            if (line.match(new RegExp(`^Function\\s+${methodName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`))) {
+                functionStartLine = i;
+                break;
+            }
+        }
+
+        if (functionStartLine === -1) {
+            return null; // Function not found
+        }
+
+        // Now count logical lines (4D lines) vs actual lines
+        // 4D counts lines ending with \ as part of the same logical line
+        // 4D treats the function declaration as line 0, so start from the next line
+        let logicalLinesCompleted = 0;
+        let lineIndex = functionStartLine + 1;
+
+        while (lineIndex < lines.length) {
+            const currentLine = lines[lineIndex];
+
+            // Check if this line ends with a continuation character
+            // Note: We need to check for \ at the end, ignoring trailing whitespace
+            const trimmedLine = currentLine.trimEnd();
+            const hasContinuation = trimmedLine.endsWith('\\');
+
+            if (!hasContinuation) {
+                // End of a logical line
+                logicalLinesCompleted++;
+
+                // Check if this is the line we're looking for
+                if (logicalLinesCompleted === lineOffset) {
+                    return lineIndex; // Found it!
+                }
+            }
+
+            lineIndex++;
+        }
+
+        // Didn't find the target line
+        return null;
+
+    } catch (err) {
+        console.error(`Error mapping function line to source line:`, err);
+        return null;
+    }
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,18 +1,10 @@
 import * as vscode from 'vscode';
 
-const testRe = /^.*\.assert\.(.*)\(.+?;(.+?);(.*?);* "(.+)"\)$/;
 const headingRe = /^.*?(?:\/\/ #tags: (.*))?\nFunction (test_.*)\(.*$/;
 
 export const parseMarkdown = (
     text: string,
     events: {
-        onTest(
-            range: vscode.Range,
-            actual: string,
-            operator: string,
-            expected: string,
-            should: string
-        ): void;
         onHeading(
             range: vscode.Range,
             name: string,
@@ -27,19 +19,6 @@ export const parseMarkdown = (
 
     for (let lineNo = 0; lineNo < lines.length; lineNo++) {
         const line = lines[lineNo];
-
-        // --- Tests ---
-        const test = testRe.exec(line);
-        if (test) {
-            const [, operator, actual, expected, should] = test;
-            const range = new vscode.Range(
-                new vscode.Position(lineNo, 0),
-                new vscode.Position(lineNo, test[0].length)
-            );
-            events.onTest(range, actual, operator, expected, should);
-            lastline = line;
-            continue;
-        }
 
         // --- Headings ---
         const combined = (lastline ? lastline + '\n' : '') + line;

--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -66,29 +66,6 @@ export async function updateFromDisk(
 
                 parent.children.push(thead);
                 ancestors.push({ item: thead, children: [] });
-            },
-
-            onTest: (range, actual, operator, expected, should) => {
-                const parent = ancestors[ancestors.length - 1];
-                if (!parent || !(parent.item.label?.startsWith('test_'))) return;
-
-                const data = new TestCase(
-                    fileItem.uri!.fsPath,
-                    actual,
-                    operator,
-                    expected,
-                    should,
-                    thisGeneration
-                );
-                const id = `${parent.item.id}/${range.start.line}`;
-                const tcase = controller.createTestItem(id, data.getLabel(), fileItem.uri);
-                tcase.range = range;
-                testData.set(tcase, data);
-
-                // Inherit tags from parent heading
-                tcase.tags = parent.item.tags;
-
-                parent.children.push(tcase);
             }
         });
 


### PR DESCRIPTION
## Summary

Refactors the extension to use function-level TestItems with nested assertion-level items (like Go subtests). This provides clear test hierarchy and precise failure locations.

## Problem

The current implementation parses individual assertions from test code and creates flat TestItems for each. This caused several issues:

1. **Table-driven tests didn't work** - Failed subtests were invisible in the UI because all assertions had the same message and couldn't be matched to TestItems
2. **Fragile text matching** - Required complex regex patterns that broke on edge cases (quoted strings, duplicate messages)
3. **Maintenance burden** - Every edge case in assertion syntax required parser updates
4. **Non-standard** - Most VS Code test extensions use function-level items only
5. **No line locations** - Failures didn't point to the exact source line

## Solution

Changed to function-level TestItems with nested assertion items:
- Parser detects test functions (removed fragile assertion parsing)
- Test tree shows: File → Functions → Assertions (like Go subtests)
- Each assertion is a separate test item with pass/fail status
- Line numbers are accurately mapped from 4D's function-relative format to actual source lines
- Inline error flags show expected vs actual values
- Functions marked as passed/failed based on overall result

## Changes

### `src/parser.ts`
- Removed `testRe` regex and assertion parsing
- Removed `onTest` callback from `parseMarkdown`
- Added `mapFunctionLineToSourceLine()` to map 4D line numbers to source locations
  - Handles line continuation characters (`\`)
  - Accounts for 4D treating function declaration as line 0

### `src/testTree.ts`
- Removed `TestCase` creation from `onTest` handler
- Simplified to only create TestItems for functions
- Clean hierarchy: File → Functions → Assertions (created at runtime)

### `src/startTestRun.ts`
- Removed `TestCase` import and assertion matching logic
- Create dynamic TestItems for each assertion when test results arrive
- Each assertion gets:
  - Label showing assertion message
  - Exact source location (clickable in editor)
  - Individual pass/fail status with inline error flag
- Inline error flags display: "Expected: X, Actual: Y"
- Parent function shows summary: "N of M assertions failed"

## Benefits

✅ **Table-driven tests work correctly** - Failures now visible in UI with subtest names  
✅ **Precise error locations** - Click any failed assertion to jump to exact source line  
✅ **Multiple failure markers** - Each failed assertion gets its own red flag in editor  
✅ **Simpler codebase** - No fragile regex matching, no "used" tracking  
✅ **More robust** - No text matching between code and results  
✅ **Standard practice** - Matches Go's subtest pattern (pytest, Jest also use nested items)  
✅ **Better failure info** - Inline flags show expected vs actual immediately  

## Testing

Tested with:
1. `DateTimeTest` - Regular assertions work correctly with individual pass/fail markers
2. `FlexPayChargeFailedNotificationJob_Test` - Table-driven test failures visible with accurate line numbers

## Test Tree Structure

```
📁 DateTimeTest.4dm
  ▸ test_minus_yieldsDuration
    ✓ expected ; got 
    ✓ expected foo@bar.com; got foo@bar.com
    ✗ expected $; got @  [line 277]  ← Clickable, shows inline error flag
    ✓ expected foo@bar.com; got foo@bar.com
    ...
```

## Breaking Changes

⚠️ **Test tree structure changes** - Users will now see assertions as nested items under functions. This matches standard testing extension patterns and provides better failure visibility.

## Related Issues

Addresses the architecture discussed in #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>