### PR TITLE
Fix test discovery for functions preceded by blank lines

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,14 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument(event => {
         discoverTests(controller, event.document.uri, getOrCreateTag);
     });
+
+    vscode.workspace.onDidCreateFiles(event => {
+        event.files.forEach(file => {
+            if (file.fsPath.endsWith('.4dm')) {
+                discoverTests(controller, file, getOrCreateTag);
+            }
+        });
+    });
 }
 
 // Discover all 4D test files

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-const headingRe = /^.*?(?:\/\/ #tags: (.*))?\nFunction (test_.*)\(.*$/;
+const headingRe = /^.*?(?:\/\/ #tags: (.*))?\n?Function (test_.*)\(.*$/;
 
 export const parseMarkdown = (
     text: string,


### PR DESCRIPTION
## Summary
This PR fixes two issues that prevented test files from being discovered:

- **Added file creation watcher**: Tests are now automatically discovered when new `.4dm` files are created, not just when files are edited or the workspace opens
- **Fixed regex pattern bug**: The pattern now handles functions preceded by blank lines by making the newline optional in the regex pattern (changed `\n` to `\n?`)

## Problem
Previously, the regex required a newline before `Function`, but the parser logic would omit the newline when the previous line was blank (empty string is falsy). This caused test files with blank lines before function definitions to not be discovered.

## Changes
- Added `onDidCreateFiles` listener in `extension.ts` to trigger test discovery for new `.4dm` files
- Updated regex pattern in `parser.ts` to make the newline before `Function` optional

## Test Plan
- [ ] Create a new test file with blank lines before function definitions
- [ ] Verify the file is automatically discovered in the test explorer
- [ ] Verify existing test files continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)