### PR TITLE
Fix skipped tests incorrectly showing as failed

### DIFF
--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -224,7 +224,9 @@ async function handleResults(
         funcItem.children.replace(assertionItems);
 
         // Mark the parent function based on overall result
-        if (testResult.passed) {
+        if (testResult.skipped) {
+            run.skipped(funcItem);
+        } else if (testResult.passed) {
             run.passed(funcItem, testResult.duration ?? 0);
         } else {
             // Build a summary message for the parent function


### PR DESCRIPTION
## Summary
- Fixes skipped tests displaying with red X (failed) icons instead of showing as skipped
- Added explicit check for `testResult.skipped` in test result handling

## Problem
When tests were marked with skip tags, they were being displayed as failed in the test explorer. The JSON output correctly showed `"skipped": true`, but the extension was treating them as failures because `testResult.passed` was `false`.

## Solution
Added a check for `testResult.skipped` before checking pass/fail status in `src/startTestRun.ts:227-228`, properly calling `run.skipped()` for skipped tests.

## Test plan
- [x] Run tests with skip tags
- [x] Verify skipped tests now show as skipped instead of failed
- [x] Verify passed and failed tests still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)