### PR TITLE
Optimize 'Run All Tests' to not specify individual tests

### DIFF
--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -10,6 +10,7 @@ export async function startTestRun(
     const run = controller.createTestRun(request);
 
     const queue: vscode.TestItem[] = [];
+    const isRunningAllTests = !request.include;
 
     if (request.include) {
         for (const test of request.include) {
@@ -62,7 +63,8 @@ export async function startTestRun(
         const profileTag = (request.profile?.label?.match(/Run '(.+)' tests/) || [])[1];
         if (profileTag) {
             cmdArgs.push(`tag=${profileTag}`);
-        } else {
+        } else if (!isRunningAllTests) {
+            // Only specify tests if not running all tests
             cmdArgs.push(`test=${uniqueTargets.join(',')}`);
         }
 


### PR DESCRIPTION
## Summary
- Optimizes the 'Run All Tests' command to omit the `test=` parameter entirely
- Prevents generation of massive command strings when running all tests

## Problem
When clicking the "Run All Tests" button in VSCode, the extension was generating a huge command explicitly listing every single test:
```
make test format=json test=RedisMemoryCache_Test.test_ErrorStr_MissingResultProperty,RedisMemoryCache_Test.test_ErrorStr_MissingTypeProperty,...
```

This creates unnecessarily long commands and is less efficient than letting the make command run all tests naturally.

## Solution
Added detection for when all tests are being run (`request.include` is undefined) and omits the `test=` parameter in that case:
- Added `isRunningAllTests` flag at [startTestRun.ts:13](src/startTestRun.ts#L13)
- Modified command building logic at [startTestRun.ts:66-68](src/startTestRun.ts#L66-L68) to only add `test=` when NOT running all tests

**Before:** `make test format=json test=Suite1.test_a,Suite1.test_b,Suite2.test_c,...`  
**After:** `make test format=json`

## Test plan
- [x] Click "Run All Tests" button and verify clean command is generated
- [x] Run individual tests and verify they still work correctly with `test=` parameter
- [x] Run tests with tag filters and verify they still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)