### PR TITLE
Add runtime error handling and display support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/gamescoot/4d-testing-extension"
   },
   "publisher": "ScottHarris",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -69,11 +69,13 @@ export async function mapFunctionLineToSourceLine(
         // Format is typically "ClassName.methodName" or just "methodName"
         const methodName = functionName.split('.').pop() || functionName;
 
-        // Find the function definition line
+        // Find the function definition line. Allow optional modifiers like
+        // `local` before the `Function` keyword (e.g., "local Function foo()").
         let functionStartLine = -1;
+        const escapedName = methodName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const funcRe = new RegExp(`^(?:\\w+\\s+)*Function\\s+${escapedName}\\s*\\(`);
         for (let i = 0; i < lines.length; i++) {
-            const line = lines[i].trim();
-            if (line.match(new RegExp(`^Function\\s+${methodName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`))) {
+            if (funcRe.test(lines[i].trim())) {
                 functionStartLine = i;
                 break;
             }
@@ -83,38 +85,87 @@ export async function mapFunctionLineToSourceLine(
             return null; // Function not found
         }
 
-        // Now count logical lines (4D lines) vs actual lines
-        // 4D counts lines ending with \ as part of the same logical line
-        // 4D treats the function declaration as line 0, so start from the next line
+        // Count logical lines (4D lines). Lines ending with `\` are continuations
+        // of the same logical line; we return the FIRST physical line of each
+        // logical line so the error lands at the start of the statement.
         let logicalLinesCompleted = 0;
+        let logicalLineStart = functionStartLine + 1;
         let lineIndex = functionStartLine + 1;
 
         while (lineIndex < lines.length) {
-            const currentLine = lines[lineIndex];
-
-            // Check if this line ends with a continuation character
-            // Note: We need to check for \ at the end, ignoring trailing whitespace
-            const trimmedLine = currentLine.trimEnd();
+            const trimmedLine = lines[lineIndex].trimEnd();
             const hasContinuation = trimmedLine.endsWith('\\');
 
             if (!hasContinuation) {
-                // End of a logical line
                 logicalLinesCompleted++;
-
-                // Check if this is the line we're looking for
                 if (logicalLinesCompleted === lineOffset) {
-                    return lineIndex; // Found it!
+                    return logicalLineStart;
                 }
+                logicalLineStart = lineIndex + 1;
             }
-
             lineIndex++;
         }
 
-        // Didn't find the target line
         return null;
 
     } catch (err) {
         console.error(`Error mapping function line to source line:`, err);
+        return null;
+    }
+}
+
+/**
+ * Maps a 4D project-method line number to the actual source file line number.
+ *
+ * Project methods don't have a `Function` declaration — the file body is the
+ * method. 4D skips a leading //%attributes directive and treats lines ending
+ * with `\` as continuations of a single logical line, so we mirror that here.
+ *
+ * @param fileUri - URI of the source file
+ * @param lineOffset - 1-based line number reported by 4D (relative to the start
+ *   of the method body, after any //%attributes)
+ * @returns The actual 0-based line number in the source file, or null on failure
+ */
+export async function mapProjectMethodLineToSourceLine(
+    fileUri: vscode.Uri,
+    lineOffset: number
+): Promise<number | null> {
+    try {
+        const rawContent = await vscode.workspace.fs.readFile(fileUri);
+        let content = new TextDecoder('utf-8').decode(rawContent);
+        if (content.charCodeAt(0) === 0xFEFF) {
+            content = content.slice(1);
+        }
+        const lines = content.split('\n');
+
+        // 4D skips a leading //%attributes line — start counting after it.
+        let startIndex = 0;
+        if (lines.length > 0 && lines[0].trimStart().startsWith('//%attributes')) {
+            startIndex = 1;
+        }
+
+        // Return the FIRST physical line of each logical line (so errors land at
+        // the start of multi-line statements joined with `\`).
+        let logicalLinesCompleted = 0;
+        let logicalLineStart = startIndex;
+        let lineIndex = startIndex;
+
+        while (lineIndex < lines.length) {
+            const trimmedLine = lines[lineIndex].trimEnd();
+            const hasContinuation = trimmedLine.endsWith('\\');
+
+            if (!hasContinuation) {
+                logicalLinesCompleted++;
+                if (logicalLinesCompleted === lineOffset) {
+                    return logicalLineStart;
+                }
+                logicalLineStart = lineIndex + 1;
+            }
+            lineIndex++;
+        }
+        return null;
+    } catch (err) {
+        console.error('Error mapping project method line to source line:', err);
         return null;
     }
 }

--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -137,8 +137,23 @@ async function handleResults(
 ) {
     if (!results.testResults) return;
 
+    if (results.hasGlobalErrors && results.globalErrors?.length > 0) {
+        run.appendOutput('\r\n⚠ Global Runtime Errors (outside test processes):\r\n');
+        for (const err of results.globalErrors) {
+            const code = err.code ?? '?';
+            const process = err.processNumber ?? '?';
+            const method = err.text || 'Unknown location';
+            const msg = err.message || err.method || '';
+            const line = err.line != null ? ` line ${err.line}` : '';
+            run.appendOutput(`  [${code}] Process ${process}: ${method}${line}\r\n`);
+            if (msg) {
+                run.appendOutput(`    ${msg}\r\n`);
+            }
+        }
+        run.appendOutput('\r\n');
+    }
+
     for (const testResult of results.testResults) {
-        // Find the TestItem for this test function
         const target = testTargets.find(
             t => t.suite === testResult.suite && t.func === testResult.name
         );
@@ -152,27 +167,27 @@ async function handleResults(
 
         const funcItem = target.item;
 
-        // Clear any existing assertion children from previous runs
+        // Pass 1: create assertion items and set their ranges
         const assertionItems: vscode.TestItem[] = [];
 
-        // Create a TestItem for each assertion
         if (testResult.assertions && testResult.assertions.length > 0) {
             for (let index = 0; index < testResult.assertions.length; index++) {
                 const assertion = testResult.assertions[index];
 
-                // Use the assertion message as the label for the test tree
-                let label = assertion.message || `Assertion ${index + 1}`;
+                let label: string;
+                if (assertion.isRuntimeError) {
+                    label = `⚠ ${assertion.message || 'Runtime error'}`;
+                } else {
+                    label = assertion.message || `Assertion ${index + 1}`;
+                }
 
-                // Truncate if too long
                 if (label.length > 80) {
                     label = label.substring(0, 77) + '...';
                 }
 
-                // Create the assertion test item
                 const assertionId = `${funcItem.id}/assertion-${index}`;
                 const assertionItem = controller.createTestItem(assertionId, label, funcItem.uri);
 
-                // Map the line number to get the exact location
                 if (assertion.line && assertion.functionName && funcItem.uri) {
                     const sourceLine = await mapFunctionLineToSourceLine(
                         funcItem.uri,
@@ -187,32 +202,46 @@ async function handleResults(
                     }
                 }
 
-                // Add to the function's children
-                assertionItems.push(assertionItem);
+                if (!assertionItem.range && funcItem.range) {
+                    assertionItem.range = funcItem.range;
+                }
 
-                // Mark the assertion as started
+                assertionItems.push(assertionItem);
+            }
+        }
+
+        // Attach items to the tree before setting run states
+        funcItem.children.replace(assertionItems);
+
+        // Pass 2: set run states now that items are in the tree
+        if (testResult.assertions && testResult.assertions.length > 0) {
+            for (let index = 0; index < testResult.assertions.length; index++) {
+                const assertion = testResult.assertions[index];
+                const assertionItem = assertionItems[index];
+
                 run.started(assertionItem);
 
-                // Mark as passed or failed
                 if (assertion.passed) {
                     run.passed(assertionItem);
                 } else {
-                    // Build detailed failure message for this assertion
-                    // Show both expected and actual on first line for inline flag
-                    const expectedStr = JSON.stringify(assertion.expected);
-                    const actualStr = JSON.stringify(assertion.actual);
-                    const failureLines: string[] = [
-                        `Expected: ${expectedStr}, Actual: ${actualStr}`
-                    ];
+                    const failureLines: string[] = [];
 
-                    // Add the original assertion message if available
-                    if (assertion.message) {
-                        failureLines.push(`\nAssertion: ${assertion.message}`);
+                    if (assertion.isRuntimeError) {
+                        failureLines.push(assertion.actual || 'Runtime error occurred');
+                        if (assertion.message) {
+                            failureLines.push(`\n${assertion.message}`);
+                        }
+                    } else {
+                        const expectedStr = JSON.stringify(assertion.expected);
+                        const actualStr = JSON.stringify(assertion.actual);
+                        failureLines.push(`Expected: ${expectedStr}, Actual: ${actualStr}`);
+                        if (assertion.message) {
+                            failureLines.push(`\nAssertion: ${assertion.message}`);
+                        }
                     }
 
                     const message = new vscode.TestMessage(failureLines.join('\n'));
 
-                    // Set location if we have it
                     if (assertionItem.range && funcItem.uri) {
                         message.location = new vscode.Location(funcItem.uri, assertionItem.range);
                     }
@@ -222,20 +251,47 @@ async function handleResults(
             }
         }
 
-        // Replace the function's children with the new assertion items
-        funcItem.children.replace(assertionItems);
-
-        // Mark the parent function based on overall result
         if (testResult.skipped) {
             run.skipped(funcItem);
         } else if (testResult.passed) {
             run.passed(funcItem, testResult.duration ?? 0);
         } else {
-            // Build a summary message for the parent function
-            const failedCount = testResult.assertions.filter((a: any) => !a.passed).length;
-            const summaryMessage = `${failedCount} of ${testResult.assertionCount} assertions failed`;
+            const summaryParts: string[] = [];
 
-            run.failed(funcItem, new vscode.TestMessage(summaryMessage), testResult.duration ?? 0);
+            if (testResult.runtimeErrors?.length > 0) {
+                const err = testResult.runtimeErrors[0];
+                const errMsg = err.message || err.method || `Error ${err.code}`;
+                summaryParts.push(`Runtime error: [${err.code}] ${errMsg}`);
+                if (err.text) {
+                    summaryParts.push(`Location: ${err.text}`);
+                }
+                if (err.line != null) {
+                    summaryParts.push(`Line: ${err.line}`);
+                }
+            } else {
+                const failedCount = testResult.assertions?.filter((a: any) => !a.passed).length ?? 0;
+                summaryParts.push(`${failedCount} of ${testResult.assertionCount} assertions failed`);
+            }
+
+            if (testResult.callChain?.length > 0) {
+                summaryParts.push('');
+                summaryParts.push('Call Stack:');
+                for (let i = 0; i < testResult.callChain.length; i++) {
+                    const frame = testResult.callChain[i];
+                    let frameLine = `  ${i + 1}. ${frame.name || '<unnamed>'}`;
+                    if (frame.type) { frameLine += ` (${frame.type})`; }
+                    if (frame.line != null) { frameLine += ` at line ${frame.line}`; }
+                    if (frame.database) { frameLine += ` in ${frame.database}`; }
+                    summaryParts.push(frameLine);
+                }
+            }
+
+            const summaryMsg = new vscode.TestMessage(summaryParts.join('\n'));
+            if (testResult.runtimeErrors?.length > 0) {
+                run.errored(funcItem, summaryMsg, testResult.duration ?? 0);
+            } else {
+                run.failed(funcItem, summaryMsg, testResult.duration ?? 0);
+            }
         }
     }
 }

--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -1,12 +1,68 @@
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
-import { mapFunctionLineToSourceLine } from './parser';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { mapFunctionLineToSourceLine, mapProjectMethodLineToSourceLine } from './parser';
+
+const LOG_PATH = path.join(os.tmpdir(), '4d-testing-extension.log');
+function dbg(msg: string) {
+    const line = `[${new Date().toISOString()}] ${msg}\n`;
+    try {
+        fs.appendFileSync(LOG_PATH, line);
+    } catch {
+        // ignore logging failures
+    }
+}
+
+// 4D sometimes emits JSON with raw control characters inside string values
+// (e.g. literal \n in an error message). JSON.parse rejects that; this walks
+// the input and escapes any unescaped control chars while inside a string.
+function escapeControlCharsInJsonStrings(s: string): string {
+    let out = '';
+    let inString = false;
+    let escaped = false;
+    for (let i = 0; i < s.length; i++) {
+        const c = s[i];
+        if (escaped) {
+            out += c;
+            escaped = false;
+            continue;
+        }
+        if (c === '\\') {
+            out += c;
+            escaped = true;
+            continue;
+        }
+        if (c === '"') {
+            inString = !inString;
+            out += c;
+            continue;
+        }
+        if (inString) {
+            const code = c.charCodeAt(0);
+            if (code === 0x0A) out += '\\n';
+            else if (code === 0x0D) out += '\\r';
+            else if (code === 0x09) out += '\\t';
+            else if (code === 0x08) out += '\\b';
+            else if (code === 0x0C) out += '\\f';
+            else if (code < 0x20) out += `\\u${code.toString(16).padStart(4, '0')}`;
+            else out += c;
+        } else {
+            out += c;
+        }
+    }
+    return out;
+}
 
 export async function startTestRun(
     controller: vscode.TestController,
     request: vscode.TestRunRequest,
     token: vscode.CancellationToken
 ) {
+    try { fs.writeFileSync(LOG_PATH, ''); } catch { /* ignore */ }
+    dbg(`startTestRun (include=${request.include?.length ?? 'all'})`);
+
     const run = controller.createTestRun(request);
 
     const queue: vscode.TestItem[] = [];
@@ -44,6 +100,9 @@ export async function startTestRun(
 
             testTargets.push({ suite, func, item: test });
         }
+        if (token.isCancellationRequested) {
+            dbg('cancellation requested during queue traversal');
+        }
 
         // Recursively process children
         test.children.forEach(child => {
@@ -57,7 +116,16 @@ export async function startTestRun(
             new Set(testTargets.map(t => `${t.suite}.${t.func}`))
         );
 
-        const cmdArgs = ['test', 'format=json'];
+        // Have the testing component write JSON to a file so we don't depend
+        // on stdout (which 4D can truncate on large runs). Use a workspace-
+        // relative path since the testing component resolves outputPath
+        // against the project root, not the OS.
+        const relOutputPath = `.4d-testing-extension/results-${Date.now()}.json`;
+        const absOutputPath = path.join(workspaceFolder, relOutputPath);
+        try {
+            fs.mkdirSync(path.dirname(absOutputPath), { recursive: true });
+        } catch { /* ignore */ }
+        const cmdArgs = ['test', 'format=json', `outputPath=${relOutputPath}`];
 
         // If profile has tag, include tag param
         const profileTag = (request.profile?.label?.match(/Run '(.+)' tests/) || [])[1];
@@ -68,65 +136,202 @@ export async function startTestRun(
             cmdArgs.push(`test=${uniqueTargets.join(',')}`);
         }
 
+        dbg(`testTargets count=${testTargets.length}`);
+        if (testTargets.length > 0) {
+            dbg(`testTargets first 5: ${testTargets.slice(0, 5).map(t => `${t.suite}.${t.func}`).join(', ')}`);
+        }
+        dbg(`spawn: make ${cmdArgs.join(' ')} (cwd=${workspaceFolder})`);
         run.appendOutput(`Spawning: make ${cmdArgs.join(' ')}\n`);
 
         await new Promise<void>(resolve => {
             const makeProcess = spawn('make', cmdArgs, { cwd: workspaceFolder });
 
-            let output = '';
-
+            // Collect raw buffers and decode once at the end so multi-byte
+            // characters don't get split across chunk boundaries.
+            const chunks: Buffer[] = [];
+            let stdoutBytes = 0;
+            let stdoutEnded = false;
             makeProcess.stdout?.on('data', (data: Buffer) => {
-                const lines = data.toString().split('\n');
-                lines.forEach(line => {
-                    if (
-                        line.startsWith('/Applications/Xcode.app') ||
-                        line.startsWith("tool4d.APPL Cooperative process doesn't yield enough")
-                    ) {
-                        return;
-                    }
-                    output += line + '\n';
-                });
+                chunks.push(data);
+                stdoutBytes += data.length;
+            });
+            makeProcess.stdout?.on('end', () => {
+                stdoutEnded = true;
+                dbg(`stdout end (${stdoutBytes} bytes received in ${chunks.length} chunks)`);
+            });
+            makeProcess.stdout?.on('error', (err) => {
+                dbg(`stdout error: ${err?.message ?? err}`);
             });
 
             makeProcess.stderr?.on('data', (data: Buffer) => {
                 run.appendOutput(data.toString());
             });
 
-            makeProcess.on('close', async () => {
+            makeProcess.on('close', async (code) => {
+                dbg(`close fired (exit=${code}, stdoutEnded=${stdoutEnded}, bytes=${stdoutBytes})`);
                 try {
-                    if (output.trim().length > 0) {
-                        // Extract JSON from output - find first { and last }
-                        const firstBrace = output.indexOf('{');
-                        const lastBrace = output.lastIndexOf('}');
-
-                        if (firstBrace === -1 || lastBrace === -1 || firstBrace > lastBrace) {
-                            run.appendOutput(`Could not find valid JSON in output\n`);
-                            resolve();
-                            return;
-                        }
-
-                        const jsonStr = output.substring(firstBrace, lastBrace + 1);
-                        const results = JSON.parse(jsonStr);
-
-                        // Pretty JSON, fixed header
-                        const pretty = JSON.stringify(results, null, 2);
-                        const prettyOutput = `\n=== Test Results (JSON) ===\n${pretty}\n`;
-                        const normalized = prettyOutput.replace(/^/gm, '\r');
-
-                        run.appendOutput("\n" + normalized + "\n");
-
-                        await handleResults(results, run, testTargets, controller);
+                    // The testing component writes to outputPath relative to
+                    // the project root. Resolve against the workspace.
+                    const candidates = [
+                        absOutputPath,
+                        path.join(workspaceFolder, relOutputPath),
+                    ];
+                    const resolvedPath = candidates.find(p => fs.existsSync(p));
+                    if (!resolvedPath) {
+                        dbg(`results file not found at: ${candidates.join(' | ')}`);
+                        run.appendOutput(`Could not find test results file\n`);
+                        resolve();
+                        return;
                     }
+
+                    const stat = fs.statSync(resolvedPath);
+                    dbg(`reading results from ${resolvedPath} (${stat.size} bytes)`);
+                    let jsonStr = fs.readFileSync(resolvedPath, 'utf8');
+                    if (jsonStr.charCodeAt(0) === 0xFEFF) {
+                        jsonStr = jsonStr.slice(1);
+                    }
+
+                    let results: any;
+                    try {
+                        results = JSON.parse(jsonStr);
+                    } catch (parseErr: any) {
+                        dbg(`JSON.parse failed: ${parseErr?.message}`);
+                        dbg('attempting sanitized retry...');
+                        try {
+                            results = JSON.parse(escapeControlCharsInJsonStrings(jsonStr));
+                            dbg('sanitized parse succeeded');
+                        } catch (retryErr: any) {
+                            dbg(`sanitized parse also failed: ${retryErr?.message}`);
+                            throw parseErr;
+                        }
+                    }
+
+                    const resultCount = Array.isArray(results?.testResults) ? results.testResults.length : 0;
+                    dbg(`parsed ${resultCount} test results`);
+
+                    dbg(`starting handleResults (testTargets=${testTargets.length})`);
+                    const startedAt = Date.now();
+                    await handleResults(results, run, testTargets, controller);
+                    dbg(`handleResults finished in ${Date.now() - startedAt}ms`);
+
+                    try { fs.unlinkSync(resolvedPath); } catch { /* ignore */ }
                 } catch (err: any) {
-                    run.appendOutput(`Error parsing JSON: ${err.message}\n`);
-                    run.appendOutput(`Output was:\n${output}\n`);
+                    dbg(`error in close handler: ${err?.message ?? err}`);
+                    dbg(`stack: ${err?.stack ?? '(no stack)'}`);
+                    run.appendOutput(`Error parsing JSON: ${err?.message ?? err}\n`);
                 }
                 resolve();
+            });
+            makeProcess.on('error', (err) => {
+                dbg(`makeProcess error: ${err?.message ?? err}`);
             });
         });
     }
 
+    dbg('calling run.end()');
     run.end();
+    dbg('run.end() returned');
+}
+
+async function fileHasAttributeLine(uri: vscode.Uri | undefined): Promise<boolean> {
+    if (!uri) return false;
+    try {
+        const rawContent = await vscode.workspace.fs.readFile(uri);
+        let content = new TextDecoder('utf-8').decode(rawContent);
+        // Strip UTF-8 BOM if present
+        if (content.charCodeAt(0) === 0xFEFF) {
+            content = content.slice(1);
+        }
+        const firstLine = content.split(/\r?\n/, 1)[0] ?? '';
+        return firstLine.trimStart().startsWith('//%attributes');
+    } catch {
+        return false;
+    }
+}
+
+async function findErrorSourceUri(err: any): Promise<vscode.Uri | undefined> {
+    // Try to find the .4dm file for the method/location reported in the error.
+    // err fields like `method` or `text` may contain a method or class name,
+    // possibly wrapped in extra prose. Pull every identifier-like token and try
+    // each as a potential filename.
+    const candidates = new Set<string>();
+    const collect = (raw: unknown) => {
+        if (typeof raw !== 'string') return;
+        const tokens = raw.match(/[A-Za-z_][A-Za-z0-9_]*/g);
+        if (tokens) tokens.forEach(t => candidates.add(t));
+    };
+    collect(err?.method);
+    collect(err?.text);
+    collect(err?.message);
+
+    for (const name of candidates) {
+        const matches = await vscode.workspace.findFiles(`**/${name}.4dm`, '**/node_modules/**', 1);
+        if (matches.length > 0) {
+            return matches[0];
+        }
+    }
+
+    return undefined;
+}
+
+const findFilesCache = new Map<string, Promise<vscode.Uri | undefined>>();
+
+async function findDmFileByName(fileBase: string): Promise<vscode.Uri | undefined> {
+    const cached = findFilesCache.get(fileBase);
+    if (cached) return cached;
+    const p = Promise.resolve(
+        vscode.workspace.findFiles(`**/${fileBase}.4dm`, '**/node_modules/**', 1)
+    ).then(matches => matches[0]);
+    findFilesCache.set(fileBase, p);
+    return p;
+}
+
+async function findFrameSourceUri(frame: any): Promise<vscode.Uri | undefined> {
+    const name = typeof frame?.name === 'string' ? frame.name : '';
+    if (!name) return undefined;
+    // classFunction names are "ClassName.methodName" — the file is ClassName.4dm.
+    // projectMethod names are just the method name — the file is methodName.4dm.
+    const fileBase = frame.type === 'classFunction' && name.includes('.')
+        ? name.split('.')[0]
+        : name;
+    return findDmFileByName(fileBase);
+}
+
+async function resolveCallFrame(frame: any): Promise<vscode.TestMessageStackFrame> {
+    const name = typeof frame?.name === 'string' ? frame.name : '';
+    const line = typeof frame?.line === 'number' ? frame.line : null;
+    const label = name || '<unnamed>';
+
+    const fileUri = await findFrameSourceUri(frame);
+
+    let position: vscode.Position | undefined;
+    if (fileUri && line !== null) {
+        let zeroBasedLine: number | null = null;
+        if (frame.type === 'classFunction' && name.includes('.')) {
+            zeroBasedLine = await mapFunctionLineToSourceLine(fileUri, name, line);
+        } else {
+            // Project method — count logical lines (handling \ continuations)
+            // from the start of the file body, skipping //%attributes.
+            zeroBasedLine = await mapProjectMethodLineToSourceLine(fileUri, line);
+        }
+        if (zeroBasedLine === null) {
+            const hasAttr = await fileHasAttributeLine(fileUri);
+            zeroBasedLine = (hasAttr ? line + 1 : line) - 1;
+        }
+        position = new vscode.Position(Math.max(0, zeroBasedLine), 0);
+    }
+
+    return new vscode.TestMessageStackFrame(label, fileUri, position);
+}
+
+function parseCallChainJSON(raw: unknown): any[] {
+    if (typeof raw !== 'string' || !raw) return [];
+    try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
 }
 
 async function handleResults(
@@ -153,145 +358,295 @@ async function handleResults(
         run.appendOutput('\r\n');
     }
 
+    let processed = 0;
+    let unmatched = 0;
+    let i = 0;
+    const totalCount = results.testResults.length;
+    dbg(`handleResults: starting loop over ${totalCount} test results, ${testTargets.length} testTargets`);
     for (const testResult of results.testResults) {
+        i++;
+        const id = `${testResult.suite}.${testResult.name}`;
         const target = testTargets.find(
             t => t.suite === testResult.suite && t.func === testResult.name
         );
 
         if (!target) {
+            unmatched++;
+            dbg(`[${i}/${totalCount}] UNMATCHED ${id} (passed=${testResult.passed} skipped=${testResult.skipped} runtimeErrors=${testResult.runtimeErrors?.length ?? 0})`);
             run.appendOutput(
-                `Warning: Could not find TestItem for ${testResult.suite}.${testResult.name}\n`
+                `Warning: Could not find TestItem for ${id}\n`
             );
             continue;
         }
 
-        const funcItem = target.item;
+        const t0 = Date.now();
+        try {
+            dbg(`[${i}/${totalCount}] start ${id} (assertions=${testResult.assertions?.length ?? 0} runtimeErrors=${testResult.runtimeErrors?.length ?? 0} passed=${testResult.passed} skipped=${testResult.skipped})`);
+            await processTestResult(testResult, target.item, run, controller);
+            processed++;
+            const elapsed = Date.now() - t0;
+            if (elapsed > 100) {
+                dbg(`[${i}/${totalCount}] done  ${id} (${elapsed}ms) [SLOW]`);
+            } else {
+                dbg(`[${i}/${totalCount}] done  ${id} (${elapsed}ms)`);
+            }
+        } catch (err: any) {
+            dbg(`[${i}/${totalCount}] ERROR ${id} (${Date.now() - t0}ms): ${err?.message ?? err}`);
+            dbg(`stack: ${err?.stack ?? '(no stack)'}`);
+            run.appendOutput(
+                `Error processing ${id}: ${err?.message ?? err}\n`
+            );
+            // Ensure the parent test doesn't stay in "running" forever.
+            run.errored(
+                target.item,
+                new vscode.TestMessage(
+                    `Internal error while processing result: ${err?.message ?? err}`
+                ),
+                testResult.duration ?? 0
+            );
+        }
+    }
+    dbg(`handleResults: processed=${processed}, unmatched=${unmatched}, total=${totalCount}`);
+}
 
-        // Pass 1: create assertion items and set their ranges
+async function processTestResult(
+    testResult: any,
+    funcItem: vscode.TestItem,
+    run: vscode.TestRun,
+    controller: vscode.TestController
+) {
+    const id = `${testResult.suite}.${testResult.name}`;
+    const realAssertions = (testResult.assertions ?? []).filter(
+            (a: any) => !a.isRuntimeError
+        );
+        const runtimeErrorAssertions = (testResult.assertions ?? []).filter(
+            (a: any) => a.isRuntimeError
+        );
+        const primaryRuntimeError =
+            testResult.runtimeErrors?.[0] ?? runtimeErrorAssertions[0];
+        const hasRuntimeError = primaryRuntimeError != null;
+        dbg(`  ${id}: realAssertions=${realAssertions.length}, hasRuntimeError=${hasRuntimeError}`);
+
+        // Pass 1: create child items (assertions + optional runtime-error child)
         const assertionItems: vscode.TestItem[] = [];
 
-        if (testResult.assertions && testResult.assertions.length > 0) {
-            for (let index = 0; index < testResult.assertions.length; index++) {
-                const assertion = testResult.assertions[index];
+        for (let index = 0; index < realAssertions.length; index++) {
+            const assertion = realAssertions[index];
 
-                let label: string;
-                if (assertion.isRuntimeError) {
-                    label = `⚠ ${assertion.message || 'Runtime error'}`;
-                } else {
-                    label = assertion.message || `Assertion ${index + 1}`;
-                }
-
-                if (label.length > 80) {
-                    label = label.substring(0, 77) + '...';
-                }
-
-                const assertionId = `${funcItem.id}/assertion-${index}`;
-                const assertionItem = controller.createTestItem(assertionId, label, funcItem.uri);
-
-                if (assertion.line && assertion.functionName && funcItem.uri) {
-                    const sourceLine = await mapFunctionLineToSourceLine(
-                        funcItem.uri,
-                        assertion.functionName,
-                        assertion.line
-                    );
-
-                    if (sourceLine !== null) {
-                        const position = new vscode.Position(sourceLine, 0);
-                        const range = new vscode.Range(position, position);
-                        assertionItem.range = range;
-                    }
-                }
-
-                if (!assertionItem.range && funcItem.range) {
-                    assertionItem.range = funcItem.range;
-                }
-
-                assertionItems.push(assertionItem);
+            let label = assertion.message || `Assertion ${index + 1}`;
+            if (label.length > 80) {
+                label = label.substring(0, 77) + '...';
             }
+
+            const assertionId = `${funcItem.id}/assertion-${index}`;
+            const assertionItem = controller.createTestItem(assertionId, label, funcItem.uri);
+
+            if (assertion.line && assertion.functionName && funcItem.uri) {
+                const sourceLine = await mapFunctionLineToSourceLine(
+                    funcItem.uri,
+                    assertion.functionName,
+                    assertion.line
+                );
+
+                if (sourceLine !== null) {
+                    const position = new vscode.Position(sourceLine, 0);
+                    const range = new vscode.Range(position, position);
+                    assertionItem.range = range;
+                }
+            }
+
+            if (!assertionItem.range && funcItem.range) {
+                assertionItem.range = funcItem.range;
+            }
+
+            assertionItems.push(assertionItem);
+        }
+
+        // Build the runtime-error child item (points at the test function, like its parent)
+        let runtimeErrorItem: vscode.TestItem | undefined;
+        if (hasRuntimeError) {
+            const err = primaryRuntimeError;
+            const errMsg = err.message || err.method || `Error ${err.code ?? ''}`.trim();
+            let label = `⚠ Runtime error: ${err.code != null ? `[${err.code}] ` : ''}${errMsg}`;
+            if (label.length > 80) {
+                label = label.substring(0, 77) + '...';
+            }
+            runtimeErrorItem = controller.createTestItem(
+                `${funcItem.id}/runtime-error`,
+                label,
+                funcItem.uri
+            );
+            if (funcItem.range) {
+                runtimeErrorItem.range = funcItem.range;
+            }
+            assertionItems.push(runtimeErrorItem);
         }
 
         // Attach items to the tree before setting run states
+        dbg(`  ${id}: built ${assertionItems.length} child items, calling children.replace`);
         funcItem.children.replace(assertionItems);
+        dbg(`  ${id}: children.replace done`);
 
-        // Pass 2: set run states now that items are in the tree
-        if (testResult.assertions && testResult.assertions.length > 0) {
-            for (let index = 0; index < testResult.assertions.length; index++) {
-                const assertion = testResult.assertions[index];
-                const assertionItem = assertionItems[index];
+        // Pass 2: set run states for assertion children
+        for (let index = 0; index < realAssertions.length; index++) {
+            const assertion = realAssertions[index];
+            const assertionItem = assertionItems[index];
 
-                run.started(assertionItem);
+            run.started(assertionItem);
 
-                if (assertion.passed) {
-                    run.passed(assertionItem);
-                } else {
-                    const failureLines: string[] = [];
-
-                    if (assertion.isRuntimeError) {
-                        failureLines.push(assertion.actual || 'Runtime error occurred');
-                        if (assertion.message) {
-                            failureLines.push(`\n${assertion.message}`);
-                        }
-                    } else {
-                        const expectedStr = JSON.stringify(assertion.expected);
-                        const actualStr = JSON.stringify(assertion.actual);
-                        failureLines.push(`Expected: ${expectedStr}, Actual: ${actualStr}`);
-                        if (assertion.message) {
-                            failureLines.push(`\nAssertion: ${assertion.message}`);
-                        }
-                    }
-
-                    const message = new vscode.TestMessage(failureLines.join('\n'));
-
-                    if (assertionItem.range && funcItem.uri) {
-                        message.location = new vscode.Location(funcItem.uri, assertionItem.range);
-                    }
-
-                    run.failed(assertionItem, message);
+            if (assertion.passed) {
+                run.passed(assertionItem);
+            } else {
+                const failureLines: string[] = [];
+                const expectedStr = JSON.stringify(assertion.expected);
+                const actualStr = JSON.stringify(assertion.actual);
+                failureLines.push(`Expected: ${expectedStr}, Actual: ${actualStr}`);
+                if (assertion.message) {
+                    failureLines.push(`\nAssertion: ${assertion.message}`);
                 }
+
+                const message = new vscode.TestMessage(failureLines.join('\n'));
+
+                if (assertionItem.range && funcItem.uri) {
+                    message.location = new vscode.Location(funcItem.uri, assertionItem.range);
+                }
+
+                run.failed(assertionItem, message);
             }
         }
 
+        // Set state on the runtime-error child (full message + stack lives here)
+        if (runtimeErrorItem && primaryRuntimeError) {
+            dbg(`  ${id}: building runtime-error message + stack trace`);
+            const err = primaryRuntimeError;
+            const summaryParts: string[] = [];
+            let errorFrame: vscode.TestMessageStackFrame | undefined;
+
+            const errMsg = err.message || err.method || `Error ${err.code ?? ''}`.trim();
+            summaryParts.push(`Runtime error: ${err.code != null ? `[${err.code}] ` : ''}${errMsg}`);
+            if (err.text) {
+                summaryParts.push(`Location: ${err.text}`);
+            }
+            // Inline decoration anchor (where the red arrow appears in the editor).
+            // Stays in the test file so the user can see it in context.
+            let decorationUri: vscode.Uri | undefined;
+            let decorationRange: vscode.Range | undefined;
+
+            if (err.line != null) {
+                const testFileBaseName = funcItem.uri
+                    ? (funcItem.uri.path.split('/').pop() ?? '').replace(/\.4dm$/, '')
+                    : '';
+                const errText = typeof err.text === 'string' ? err.text : '';
+                const isInTestClass = testFileBaseName !== '' && errText !== '' &&
+                    (errText === testFileBaseName || errText.startsWith(`${testFileBaseName}.`));
+
+                // Resolve the actual error location (file + 0-based line) for the stack frame.
+                let errorSourceUri: vscode.Uri | undefined;
+                let errorZeroBasedLine: number | null = null;
+
+                if (isInTestClass && funcItem.uri) {
+                    errorSourceUri = funcItem.uri;
+                    errorZeroBasedLine = await mapFunctionLineToSourceLine(
+                        funcItem.uri,
+                        errText,
+                        err.line
+                    );
+                } else {
+                    errorSourceUri = await findErrorSourceUri(err);
+                    if (errorSourceUri) {
+                        if (errText && errText.includes('.')) {
+                            errorZeroBasedLine = await mapFunctionLineToSourceLine(
+                                errorSourceUri,
+                                errText,
+                                err.line
+                            );
+                        } else {
+                            // Project method — count logical lines with \ continuations
+                            errorZeroBasedLine = await mapProjectMethodLineToSourceLine(
+                                errorSourceUri,
+                                err.line
+                            );
+                        }
+                        if (errorZeroBasedLine === null) {
+                            const hasAttr = await fileHasAttributeLine(errorSourceUri);
+                            errorZeroBasedLine = (hasAttr ? err.line + 1 : err.line) - 1;
+                        }
+                    }
+                }
+
+                summaryParts.push(
+                    `Line: ${errorZeroBasedLine !== null ? errorZeroBasedLine + 1 : err.line}`
+                );
+
+                // Stack frame always points at the actual error location.
+                if (errorSourceUri && errorZeroBasedLine !== null) {
+                    const pos = new vscode.Position(errorZeroBasedLine, 0);
+                    const label = errText || err.method || 'Error location';
+                    errorFrame = new vscode.TestMessageStackFrame(label, errorSourceUri, pos);
+                }
+
+                // Decoration anchor: actual line if in the test class, otherwise the test function.
+                if (isInTestClass && errorSourceUri && errorZeroBasedLine !== null) {
+                    const pos = new vscode.Position(errorZeroBasedLine, 0);
+                    decorationUri = errorSourceUri;
+                    decorationRange = new vscode.Range(pos, pos);
+                } else if (funcItem.uri && funcItem.range) {
+                    decorationUri = funcItem.uri;
+                    decorationRange = funcItem.range;
+                }
+            }
+
+            // Resolve every call-chain frame to a clickable TestMessageStackFrame.
+            // The VS Code stack trace UI renders these directly — no need to
+            // duplicate them in the message body.
+            const errCallChain = parseCallChainJSON(err.callChainJSON);
+            const chainForStack = errCallChain.length > 0 ? errCallChain : (testResult.callChain ?? []);
+            dbg(`  ${id}: resolving ${chainForStack.length} stack frames`);
+            const tStack = Date.now();
+
+            const stackFrames: vscode.TestMessageStackFrame[] = [];
+            for (const frame of chainForStack) {
+                stackFrames.push(await resolveCallFrame(frame));
+            }
+            dbg(`  ${id}: resolved ${stackFrames.length} frames in ${Date.now() - tStack}ms`);
+
+            const message = new vscode.TestMessage(summaryParts.join('\n'));
+            if (decorationUri && decorationRange) {
+                message.location = new vscode.Location(decorationUri, decorationRange);
+                runtimeErrorItem.range = decorationRange;
+            } else if (funcItem.uri && runtimeErrorItem.range) {
+                message.location = new vscode.Location(funcItem.uri, runtimeErrorItem.range);
+            }
+            if (stackFrames.length > 0) {
+                message.stackTrace = stackFrames;
+            } else if (errorFrame) {
+                message.stackTrace = [errorFrame];
+            }
+
+            run.started(runtimeErrorItem);
+            run.errored(runtimeErrorItem, message);
+            dbg(`  ${id}: runtime-error child marked errored`);
+        }
+
+        // Parent state — when a runtime error occurs, the runtime-error child
+        // owns the failure entry; mark the parent as passed so it doesn't
+        // duplicate the failure in the Test Results output. The child's errored
+        // state still propagates to the parent's icon in the Test Explorer tree.
         if (testResult.skipped) {
+            dbg(`  ${id}: parent → skipped`);
             run.skipped(funcItem);
+        } else if (hasRuntimeError) {
+            dbg(`  ${id}: parent → passed (runtime error owns failure)`);
+            run.passed(funcItem, testResult.duration ?? 0);
         } else if (testResult.passed) {
+            dbg(`  ${id}: parent → passed`);
             run.passed(funcItem, testResult.duration ?? 0);
         } else {
-            const summaryParts: string[] = [];
-
-            if (testResult.runtimeErrors?.length > 0) {
-                const err = testResult.runtimeErrors[0];
-                const errMsg = err.message || err.method || `Error ${err.code}`;
-                summaryParts.push(`Runtime error: [${err.code}] ${errMsg}`);
-                if (err.text) {
-                    summaryParts.push(`Location: ${err.text}`);
-                }
-                if (err.line != null) {
-                    summaryParts.push(`Line: ${err.line}`);
-                }
-            } else {
-                const failedCount = testResult.assertions?.filter((a: any) => !a.passed).length ?? 0;
-                summaryParts.push(`${failedCount} of ${testResult.assertionCount} assertions failed`);
-            }
-
-            if (testResult.callChain?.length > 0) {
-                summaryParts.push('');
-                summaryParts.push('Call Stack:');
-                for (let i = 0; i < testResult.callChain.length; i++) {
-                    const frame = testResult.callChain[i];
-                    let frameLine = `  ${i + 1}. ${frame.name || '<unnamed>'}`;
-                    if (frame.type) { frameLine += ` (${frame.type})`; }
-                    if (frame.line != null) { frameLine += ` at line ${frame.line}`; }
-                    if (frame.database) { frameLine += ` in ${frame.database}`; }
-                    summaryParts.push(frameLine);
-                }
-            }
-
-            const summaryMsg = new vscode.TestMessage(summaryParts.join('\n'));
-            if (testResult.runtimeErrors?.length > 0) {
-                run.errored(funcItem, summaryMsg, testResult.duration ?? 0);
-            } else {
-                run.failed(funcItem, summaryMsg, testResult.duration ?? 0);
-            }
+            const failedCount = testResult.assertions?.filter((a: any) => !a.passed).length ?? 0;
+            dbg(`  ${id}: parent → failed (${failedCount}/${testResult.assertionCount} assertions failed)`);
+            const summaryMsg = new vscode.TestMessage(
+                `${failedCount} of ${testResult.assertionCount} assertions failed`
+            );
+            run.failed(funcItem, summaryMsg, testResult.duration ?? 0);
         }
-    }
 }


### PR DESCRIPTION
## Summary
- Display runtime errors distinctly from assertion failures in the Test Explorer (⚠ label prefix, error details instead of expected/actual)
- Show error code, message, location, and call stack in failure messages for tests with runtime errors
- Surface global runtime errors (outside test processes) in the test output panel
- Fix assertion items not showing run state (pass/fail) by attaching them to the tree before setting state

## Test plan
1. Checkout the `handle-errors-better` branch
2. Open the project in VSCode. Disable **4d-testing-extension** if you already have it installed, then `Cmd+Shift+P` → **Reload Window**
3. Click the **Run Extension** play button in the left panel
4. A new VSCode instance will start with the extension loaded
5. Open **symphony**
6. Wait for the testing icon to appear on the left panel (flask icon)
7. Open that icon and search for **updatesol**
8. Click the play button on the **UpdateSOLocationTest** line to run the tests
9. The tests should all succeed
10. Now open the test file and make the following change to the `test_empty_updates_collection` function:
    ```4d
    // #tags: unit, fast
    Function test_empty_updates_collection($t : cs.Testing.Testing)
        var $result : Object
        var $updates : Collection
        ALERT($result.length)
        $updates:=New collection
        $result:=UpdateSOLocation($updates)

        $t.assert.areEqual($t; 0; $result.status; "Empty collection should fail")
        $t.assert.areEqual($t; FourQCodes_FAIL_NOW; $result.result.fourq_code; "Should return FAIL_NOW code")
        $t.assert.areEqual($t; "No updates provided"; $result.message; "Should have correct error message")
    ```
11. Run the test again — it should error. Most assertions will show passed, but the one we changed will have a **red X** next to it and an error on the error line.