### PR TITLE
feat: surface external errors in Test Explorer with full stack traces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,26 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { startTestRun } from './startTestRun';
 import { updateFromDisk, testData } from './testTree';
 
+const LOG_PATH = path.join(os.tmpdir(), '4d-testing-extension.log');
+function dbg(msg: string) {
+    const line = `[${new Date().toISOString()}] [discovery] ${msg}\n`;
+    try { fs.appendFileSync(LOG_PATH, line); } catch { /* ignore */ }
+}
+
+function countItems(collection: vscode.TestItemCollection): number {
+    let n = 0;
+    collection.forEach(() => n++);
+    return n;
+}
+
+let discoveryGeneration = Date.now();
+
 export function activate(context: vscode.ExtensionContext) {
+    dbg('activate() called');
     const controller = vscode.tests.createTestController(
         'fourDTestController',
         '4D Tests'
@@ -68,26 +86,41 @@ export function activate(context: vscode.ExtensionContext) {
         (request, token) => runTests(controller, request, token)
     );
 
-    // Discover tests when workspace opens or folders change
+    // Discover tests when workspace opens, then clear stale results
     if (vscode.workspace.workspaceFolders) {
-        vscode.workspace.workspaceFolders.forEach(folder =>
-            discoverTests(controller, folder.uri, getOrCreateTag)
-        );
+        dbg(`initial discovery for ${vscode.workspace.workspaceFolders.length} workspace folder(s)`);
+        const folders = [...vscode.workspace.workspaceFolders];
+        (async () => {
+            for (const folder of folders) {
+                dbg(`  folder: ${folder.uri.fsPath}`);
+                await discoverTests(controller, folder.uri, getOrCreateTag);
+            }
+            dbg(`invalidateTestResults() — root items: ${countItems(controller.items)}`);
+            controller.invalidateTestResults();
+        })();
+    } else {
+        dbg('no workspace folders found');
     }
 
     vscode.workspace.onDidChangeWorkspaceFolders(event => {
+        dbg(`onDidChangeWorkspaceFolders: added=${event.added.length} removed=${event.removed.length}`);
         event.added.forEach(folder =>
             discoverTests(controller, folder.uri, getOrCreateTag)
         );
     });
 
     vscode.workspace.onDidChangeTextDocument(event => {
-        discoverTests(controller, event.document.uri, getOrCreateTag);
+        if (event.document.uri.fsPath.endsWith('.4dm')) {
+            dbg(`onDidChangeTextDocument: ${event.document.uri.fsPath} (root items: ${countItems(controller.items)})`);
+            controller.invalidateTestResults();
+            discoverTests(controller, event.document.uri, getOrCreateTag);
+        }
     });
 
     vscode.workspace.onDidCreateFiles(event => {
         event.files.forEach(file => {
             if (file.fsPath.endsWith('.4dm')) {
+                dbg(`onDidCreateFiles: ${file.fsPath}`);
                 discoverTests(controller, file, getOrCreateTag);
             }
         });
@@ -100,20 +133,33 @@ async function discoverTests(
     rootUri: vscode.Uri,
     getOrCreateTag: (name: string) => vscode.TestTag
 ) {
+    discoveryGeneration++;
+    const gen = discoveryGeneration;
+    dbg(`discoverTests called (gen=${gen}): ${rootUri.fsPath}`);
     try {
         let files: vscode.Uri[];
         if (rootUri.toString().endsWith('.4dm')) {
             files = [rootUri];
+            dbg(`  single file mode`);
         } else {
             const pattern = new vscode.RelativePattern(
                 vscode.Uri.joinPath(rootUri, 'Project', 'Sources', 'Classes'),
                 '*Test.4dm'
             );
             files = await vscode.workspace.findFiles(pattern);
+            dbg(`  found ${files.length} *Test.4dm files`);
         }
 
+        // Remove all existing root items so VS Code drops cached result state
+        const staleIds: string[] = [];
+        controller.items.forEach(item => staleIds.push(item.id));
+        for (const id of staleIds) {
+            controller.items.delete(id);
+        }
+        dbg(`  cleared ${staleIds.length} stale root items`);
+
         for (const file of files) {
-            const id = file.fsPath;
+            const id = `g${gen}:${file.fsPath}`;
             const testItem = controller.createTestItem(
                 id,
                 file.path.split('/').pop()!,
@@ -121,10 +167,14 @@ async function discoverTests(
             );
             controller.items.add(testItem);
             testData.set(testItem, { kind: 'file' });
+            dbg(`  added file item: ${file.path.split('/').pop()!} (children before updateFromDisk: ${countItems(testItem.children)})`);
 
-            await updateFromDisk(controller, testItem, getOrCreateTag);
+            await updateFromDisk(controller, testItem, getOrCreateTag, gen);
+            dbg(`  after updateFromDisk: ${file.path.split('/').pop()!} has ${countItems(testItem.children)} children`);
         }
-    } catch (err) {
+        dbg(`  root items after discovery: ${countItems(controller.items)}`);
+    } catch (err: any) {
+        dbg(`  ERROR in discoverTests: ${err?.message ?? err}`);
         console.error('Error discovering 4D tests:', err);
     }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,26 @@
 import * as vscode from 'vscode';
 
+const fileContentCache = new Map<string, string[]>();
+
+export async function getFileLines(fileUri: vscode.Uri): Promise<string[]> {
+    const key = fileUri.toString();
+    const cached = fileContentCache.get(key);
+    if (cached) return cached;
+
+    const rawContent = await vscode.workspace.fs.readFile(fileUri);
+    let content = new TextDecoder('utf-8').decode(rawContent);
+    if (content.charCodeAt(0) === 0xFEFF) {
+        content = content.slice(1);
+    }
+    const lines = content.split('\n');
+    fileContentCache.set(key, lines);
+    return lines;
+}
+
+export function clearFileContentCache() {
+    fileContentCache.clear();
+}
+
 const headingRe = /^.*?(?:\/\/ #tags: (.*))?\n?Function (test_.*)\(.*$/;
 
 export const parseMarkdown = (
@@ -60,10 +81,7 @@ export async function mapFunctionLineToSourceLine(
     lineOffset: number
 ): Promise<number | null> {
     try {
-        // Read the source file
-        const rawContent = await vscode.workspace.fs.readFile(fileUri);
-        const content = new TextDecoder().decode(rawContent);
-        const lines = content.split('\n');
+        const lines = await getFileLines(fileUri);
 
         // Extract the method name from the fully qualified name
         // Format is typically "ClassName.methodName" or just "methodName"
@@ -131,12 +149,7 @@ export async function mapProjectMethodLineToSourceLine(
     lineOffset: number
 ): Promise<number | null> {
     try {
-        const rawContent = await vscode.workspace.fs.readFile(fileUri);
-        let content = new TextDecoder('utf-8').decode(rawContent);
-        if (content.charCodeAt(0) === 0xFEFF) {
-            content = content.slice(1);
-        }
-        const lines = content.split('\n');
+        const lines = await getFileLines(fileUri);
 
         // 4D skips a leading //%attributes line — start counting after it.
         let startIndex = 0;

--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -125,7 +125,7 @@ export async function startTestRun(
         try {
             fs.mkdirSync(path.dirname(absOutputPath), { recursive: true });
         } catch { /* ignore */ }
-        const cmdArgs = ['test', 'format=json', `outputPath=${relOutputPath}`];
+        const cmdArgs = ['test', 'format=json', 'callchain=true', `outputPath=${relOutputPath}`];
 
         // If profile has tag, include tag param
         const profileTag = (request.profile?.label?.match(/Run '(.+)' tests/) || [])[1];
@@ -213,6 +213,13 @@ export async function startTestRun(
                     const startedAt = Date.now();
                     await handleResults(results, run, testTargets, controller);
                     dbg(`handleResults finished in ${Date.now() - startedAt}ms`);
+
+                    const stdout = Buffer.concat(chunks).toString('utf8').trim();
+                    if (stdout) {
+                        for (const line of stdout.split(/\r?\n/)) {
+                            run.appendOutput(line + '\r\n');
+                        }
+                    }
 
                     try { fs.unlinkSync(resolvedPath); } catch { /* ignore */ }
                 } catch (err: any) {
@@ -340,22 +347,96 @@ async function handleResults(
     testTargets: { suite: string; func: string; item: vscode.TestItem }[],
     controller: vscode.TestController
 ) {
+    controller.items.delete('__external_errors__');
+
     if (!results.testResults) return;
 
     if (results.hasGlobalErrors && results.globalErrors?.length > 0) {
-        run.appendOutput('\r\n⚠ Global Runtime Errors (outside test processes):\r\n');
+        // Deduplicate errors by their signature (code + location + line + message)
+        const uniqueErrors: { err: any; count: number }[] = [];
+        const seen = new Map<string, number>();
         for (const err of results.globalErrors) {
+            const key = `${err.code ?? '?'}|${err.text || ''}|${err.line ?? ''}|${err.message || err.method || ''}`;
+            const idx = seen.get(key);
+            if (idx !== undefined) {
+                uniqueErrors[idx].count++;
+            } else {
+                seen.set(key, uniqueErrors.length);
+                uniqueErrors.push({ err, count: 1 });
+            }
+        }
+
+        const totalCount = results.globalErrors.length;
+        const extErrorsItem = controller.createTestItem(
+            '__external_errors__',
+            `External Errors (${totalCount})`
+        );
+
+        const childItems: vscode.TestItem[] = [];
+        for (let i = 0; i < uniqueErrors.length; i++) {
+            const { err, count } = uniqueErrors[i];
+            const msg = err.message || err.method || `Error ${err.code}`;
+            const suffix = count > 1 ? ` (x${count})` : '';
+
+            const sourceUri = await findErrorSourceUri(err);
+            const child = controller.createTestItem(
+                `__external_errors__/${i}`,
+                `[${err.code ?? '?'}] ${msg}${suffix}`,
+                sourceUri
+            );
+
+            if (sourceUri && err.line != null) {
+                const errText = typeof err.text === 'string' ? err.text : '';
+                let zeroBasedLine: number | null = null;
+                if (errText && errText.includes('.')) {
+                    zeroBasedLine = await mapFunctionLineToSourceLine(sourceUri, errText, err.line);
+                } else {
+                    zeroBasedLine = await mapProjectMethodLineToSourceLine(sourceUri, err.line);
+                }
+                if (zeroBasedLine === null) {
+                    const hasAttr = await fileHasAttributeLine(sourceUri);
+                    zeroBasedLine = (hasAttr ? err.line + 1 : err.line) - 1;
+                }
+                const pos = new vscode.Position(Math.max(0, zeroBasedLine), 0);
+                child.range = new vscode.Range(pos, pos);
+            }
+
+            childItems.push(child);
+        }
+
+        extErrorsItem.children.replace(childItems);
+        controller.items.add(extErrorsItem);
+
+        for (let i = 0; i < childItems.length; i++) {
+            const { err, count } = uniqueErrors[i];
             const code = err.code ?? '?';
-            const process = err.processNumber ?? '?';
             const method = err.text || 'Unknown location';
             const msg = err.message || err.method || '';
             const line = err.line != null ? ` line ${err.line}` : '';
-            run.appendOutput(`  [${code}] Process ${process}: ${method}${line}\r\n`);
-            if (msg) {
-                run.appendOutput(`    ${msg}\r\n`);
+            const countNote = count > 1 ? `\nOccurred ${count} times` : '';
+            const detail = `[${code}] ${method}${line}${msg ? '\n' + msg : ''}${countNote}`;
+            const message = new vscode.TestMessage(detail);
+
+            if (childItems[i].uri && childItems[i].range) {
+                message.location = new vscode.Location(childItems[i].uri!, childItems[i].range!);
             }
+
+            const callChain = parseCallChainJSON(err.callChainJSON);
+            if (callChain.length > 0) {
+                const stackFrames: vscode.TestMessageStackFrame[] = [];
+                for (const frame of callChain) {
+                    stackFrames.push(await resolveCallFrame(frame));
+                }
+                message.stackTrace = stackFrames;
+            }
+
+            run.started(childItems[i]);
+            run.errored(childItems[i], message);
         }
-        run.appendOutput('\r\n');
+        run.started(extErrorsItem);
+        run.errored(extErrorsItem, new vscode.TestMessage(
+            `${totalCount} external runtime error(s) detected (${uniqueErrors.length} unique)`
+        ));
     }
 
     let processed = 0;

--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -3,7 +3,7 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { mapFunctionLineToSourceLine, mapProjectMethodLineToSourceLine } from './parser';
+import { mapFunctionLineToSourceLine, mapProjectMethodLineToSourceLine, clearFileContentCache, getFileLines } from './parser';
 
 const LOG_PATH = path.join(os.tmpdir(), '4d-testing-extension.log');
 function dbg(msg: string) {
@@ -145,6 +145,20 @@ export async function startTestRun(
 
         await new Promise<void>(resolve => {
             const makeProcess = spawn('make', cmdArgs, { cwd: workspaceFolder });
+            let cancelled = false;
+
+            const cancelSub = token.onCancellationRequested(() => {
+                cancelled = true;
+                dbg('cancellation requested — killing make process');
+                run.appendOutput('Test run cancelled.\r\n');
+                makeProcess.kill('SIGTERM');
+                setTimeout(() => {
+                    if (!makeProcess.killed) {
+                        dbg('SIGTERM did not kill process, sending SIGKILL');
+                        makeProcess.kill('SIGKILL');
+                    }
+                }, 3000);
+            });
 
             // Collect raw buffers and decode once at the end so multi-byte
             // characters don't get split across chunk boundaries.
@@ -168,7 +182,13 @@ export async function startTestRun(
             });
 
             makeProcess.on('close', async (code) => {
-                dbg(`close fired (exit=${code}, stdoutEnded=${stdoutEnded}, bytes=${stdoutBytes})`);
+                cancelSub.dispose();
+                dbg(`close fired (exit=${code}, cancelled=${cancelled}, stdoutEnded=${stdoutEnded}, bytes=${stdoutBytes})`);
+
+                if (cancelled) {
+                    resolve();
+                    return;
+                }
                 try {
                     // The testing component writes to outputPath relative to
                     // the project root. Resolve against the workspace.
@@ -235,6 +255,8 @@ export async function startTestRun(
         });
     }
 
+    clearFileContentCache();
+    findFilesCache.clear();
     dbg('calling run.end()');
     run.end();
     dbg('run.end() returned');
@@ -243,24 +265,14 @@ export async function startTestRun(
 async function fileHasAttributeLine(uri: vscode.Uri | undefined): Promise<boolean> {
     if (!uri) return false;
     try {
-        const rawContent = await vscode.workspace.fs.readFile(uri);
-        let content = new TextDecoder('utf-8').decode(rawContent);
-        // Strip UTF-8 BOM if present
-        if (content.charCodeAt(0) === 0xFEFF) {
-            content = content.slice(1);
-        }
-        const firstLine = content.split(/\r?\n/, 1)[0] ?? '';
-        return firstLine.trimStart().startsWith('//%attributes');
+        const lines = await getFileLines(uri);
+        return lines.length > 0 && lines[0].trimStart().startsWith('//%attributes');
     } catch {
         return false;
     }
 }
 
 async function findErrorSourceUri(err: any): Promise<vscode.Uri | undefined> {
-    // Try to find the .4dm file for the method/location reported in the error.
-    // err fields like `method` or `text` may contain a method or class name,
-    // possibly wrapped in extra prose. Pull every identifier-like token and try
-    // each as a potential filename.
     const candidates = new Set<string>();
     const collect = (raw: unknown) => {
         if (typeof raw !== 'string') return;
@@ -272,10 +284,8 @@ async function findErrorSourceUri(err: any): Promise<vscode.Uri | undefined> {
     collect(err?.message);
 
     for (const name of candidates) {
-        const matches = await vscode.workspace.findFiles(`**/${name}.4dm`, '**/node_modules/**', 1);
-        if (matches.length > 0) {
-            return matches[0];
-        }
+        const uri = await findDmFileByName(name);
+        if (uri) return uri;
     }
 
     return undefined;
@@ -439,6 +449,11 @@ async function handleResults(
         ));
     }
 
+    const targetMap = new Map<string, vscode.TestItem>();
+    for (const t of testTargets) {
+        targetMap.set(`${t.suite}.${t.func}`, t.item);
+    }
+
     let processed = 0;
     let unmatched = 0;
     let i = 0;
@@ -447,11 +462,9 @@ async function handleResults(
     for (const testResult of results.testResults) {
         i++;
         const id = `${testResult.suite}.${testResult.name}`;
-        const target = testTargets.find(
-            t => t.suite === testResult.suite && t.func === testResult.name
-        );
+        const targetItem = targetMap.get(id);
 
-        if (!target) {
+        if (!targetItem) {
             unmatched++;
             dbg(`[${i}/${totalCount}] UNMATCHED ${id} (passed=${testResult.passed} skipped=${testResult.skipped} runtimeErrors=${testResult.runtimeErrors?.length ?? 0})`);
             run.appendOutput(
@@ -463,7 +476,7 @@ async function handleResults(
         const t0 = Date.now();
         try {
             dbg(`[${i}/${totalCount}] start ${id} (assertions=${testResult.assertions?.length ?? 0} runtimeErrors=${testResult.runtimeErrors?.length ?? 0} passed=${testResult.passed} skipped=${testResult.skipped})`);
-            await processTestResult(testResult, target.item, run, controller);
+            await processTestResult(testResult, targetItem, run, controller);
             processed++;
             const elapsed = Date.now() - t0;
             if (elapsed > 100) {
@@ -479,7 +492,7 @@ async function handleResults(
             );
             // Ensure the parent test doesn't stay in "running" forever.
             run.errored(
-                target.item,
+                targetItem,
                 new vscode.TestMessage(
                     `Internal error while processing result: ${err?.message ?? err}`
                 ),

--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -1,5 +1,14 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { parseMarkdown } from './parser';
+
+const LOG_PATH = path.join(os.tmpdir(), '4d-testing-extension.log');
+function dbg(msg: string) {
+    const line = `[${new Date().toISOString()}] [testTree] ${msg}\n`;
+    try { fs.appendFileSync(LOG_PATH, line); } catch { /* ignore */ }
+}
 
 export const testData = new WeakMap<vscode.TestItem, TestCase | TestHeading | FileData>();
 
@@ -27,8 +36,15 @@ export type FileData = { kind: 'file' };
 export async function updateFromDisk(
     controller: vscode.TestController,
     fileItem: vscode.TestItem,
-    getOrCreateTag: (name: string) => vscode.TestTag
+    getOrCreateTag: (name: string) => vscode.TestTag,
+    generation?: number
 ) {
+    const fileName = fileItem.uri?.path.split('/').pop() ?? fileItem.id;
+    dbg(`updateFromDisk: ${fileName}`);
+    let oldChildCount = 0;
+    fileItem.children.forEach(() => oldChildCount++);
+    dbg(`  existing children before parse: ${oldChildCount}`);
+
     try {
         const rawContent = await vscode.workspace.fs.readFile(fileItem.uri!);
         const content = new TextDecoder().decode(rawContent);
@@ -40,22 +56,26 @@ export async function updateFromDisk(
         const ascend = (depth: number) => {
             while (ancestors.length > depth) {
                 const finished = ancestors.pop()!;
+                dbg(`  children.replace on "${finished.item.label}": ${finished.children.length} new children`);
                 finished.item.children.replace(finished.children);
             }
         };
 
         const thisGeneration = Date.now();
         let hasFunction = false;
+        let headingCount = 0;
 
         parseMarkdown(content, {
             onHeading: (range, name, depth, headingTags) => {
+                headingCount++;
                 if (name.startsWith('test_')) {
                     hasFunction = true;
                 }
 
                 ascend(depth);
                 const parent = ancestors[ancestors.length - 1];
-                const id = `${fileItem.uri}/${name}`;
+                const genPrefix = generation != null ? `g${generation}:` : '';
+                const id = `${genPrefix}${fileItem.uri}/${name}`;
                 const thead = controller.createTestItem(id, name, fileItem.uri);
                 thead.range = range;
                 testData.set(thead, new TestHeading(thisGeneration));
@@ -69,13 +89,20 @@ export async function updateFromDisk(
             }
         });
 
+        dbg(`  parsed ${headingCount} headings, hasFunction=${hasFunction}`);
+
         // Remove file if no valid functions
         if (!hasFunction) {
+            dbg(`  removing file item (no test functions found)`);
             controller.items.delete(fileItem.id);
         }
 
         ascend(0);
-    } catch (err) {
+        let newChildCount = 0;
+        fileItem.children.forEach(() => newChildCount++);
+        dbg(`  final children after ascend: ${newChildCount}`);
+    } catch (err: any) {
+        dbg(`  ERROR: ${err?.message ?? err}`);
         console.error(`Error reading/parsing file ${fileItem.uri?.fsPath}:`, err);
     }
 }


### PR DESCRIPTION
## Summary

Global runtime errors (errors caught by the global error handler outside any test process) were previously only written to the output panel as text and invisible in the Test Explorer tree. This PR makes them first-class citizens in the testing UI:

- **Synthetic tree node**: When global errors are present, an "External Errors (N)" parent item appears at the root of the Test Explorer with a deduplicated child per unique error, showing `(xN)` occurrence counts
- **Clickable source links**: Each external error resolves to its source `.4dm` file and line number, so clicking it in the tree opens the file at the error location
- **Full stack traces**: Passes `callchain=true` to the testing component and resolves call chain frames into VS Code `TestMessageStackFrame` entries, rendering a clickable call stack in the Test Results pane
- **Component stdout as output**: Pipes the testing component's human-readable stdout (full summary with pass/fail/skip/assertion counts, duration, deduplicated error list) directly to the Test Results pane, replacing the extension's own duplicate formatting
- **Stale cleanup**: Previous "External Errors" nodes are removed at the start of each run so they don't persist when a subsequent run has no global errors
- **Performance**: File content cache ensures each `.4dm` file is read once per run instead of thousands of times during line mapping; `findErrorSourceUri` uses cached file lookups; test target matching uses a Map instead of linear scan
- **Cancellation support**: Hooking up the VS Code cancellation token to kill the spawned `make` process immediately via SIGTERM (with SIGKILL fallback) when the user cancels a test run
- **Discovery improvements**: Generation-based test item IDs and `invalidateTestResults()` to clear stale cached results on re-discovery, plus debug logging throughout discovery and test tree parsing

## Test plan

- [ ] Run all tests with a project that produces global runtime errors; verify the "External Errors (N)" node appears in the Test Explorer tree with deduplicated children and correct `(xN)` counts
- [ ] Click an external error child item in the tree and verify it opens the correct `.4dm` source file at the error line
- [ ] Expand an external error that has a call chain and verify the full stack trace appears in VS Code's stack trace UI with clickable frames
- [ ] Verify the Test Results output pane shows the component's human-readable summary (total tests, passed, failed, skipped, assertions, pass rate, duration, external errors)
- [ ] Run tests again with no global errors and verify the "External Errors" node is removed from the tree
- [ ] Run a subset of tests (not "Run All") and verify normal test results still work correctly with no regressions
- [ ] Cancel a test run mid-execution and verify the run stops promptly (the make process is killed and the spinner goes away)
- [ ] Compare "Run All Tests" wall-clock time in VS Code vs `make test` on the command line and verify the gap has narrowed