### PR TITLE
Add a setting for tool4d location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "4d-testing-extension",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "4d-testing-extension",
-      "version": "0.0.8",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^20.11.30",
         "@types/vscode": "^1.85.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "4D Testing Extension",
+      "properties": {
+        "4d-testing-extension.tool4dPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the tool4D (or 4D) executable. Passed as the TOOL4D parameter to make. Leave empty to use the Makefile default."
+        }
+      }
+    },
     "commands": [
       {
         "command": "4d-testing-extension.runTests",

--- a/src/startTestRun.ts
+++ b/src/startTestRun.ts
@@ -127,6 +127,11 @@ export async function startTestRun(
         } catch { /* ignore */ }
         const cmdArgs = ['test', 'format=json', `outputPath=${relOutputPath}`];
 
+        const tool4dPath = vscode.workspace.getConfiguration('4d-testing-extension').get<string>('tool4dPath');
+        if (tool4dPath) {
+            cmdArgs.push(`TOOL4D=${tool4dPath}`);
+        }
+
         // If profile has tag, include tag param
         const profileTag = (request.profile?.label?.match(/Run '(.+)' tests/) || [])[1];
         if (profileTag) {


### PR DESCRIPTION
I added a setting to the extension that allows for users to configure a different location than the hard-coded path for tool4d used in Symphony. This will allow us to point the extension at other versions.